### PR TITLE
Remove compiler warnings

### DIFF
--- a/demo/demo.c
+++ b/demo/demo.c
@@ -576,7 +576,7 @@ show_test_window(struct zr_window *window, struct zr_style *config, enum theme *
 
             /* progressbar combobox */
             sum = x + y + z + w;
-            sprintf(buffer, "%lu", sum);
+            sprintf(buffer, "%" PRIu64, sum);
             zr_combo_begin(&layout, &combo, buffer, &prog_active);
             {
                 zr_layout_row_dynamic(&combo, 30, 1);
@@ -589,7 +589,7 @@ show_test_window(struct zr_window *window, struct zr_style *config, enum theme *
 
             /* checkbox combobox */
             sum = (size_t)(check_values[0] + check_values[1] + check_values[2] + check_values[3] + check_values[4]);
-            sprintf(buffer, "%lu", sum);
+            sprintf(buffer, "%" PRIu64, sum);
             zr_combo_begin(&layout, &combo, buffer, &check_active);
             {
                 zr_layout_row_dynamic(&combo, 30, 1);

--- a/zahnrad.c
+++ b/zahnrad.c
@@ -207,7 +207,7 @@ zr_memcopy(void *dst0, const void *src0, zr_size length)
     #define TLOOP(s) if (t) TLOOP1(s)
     #define TLOOP1(s) do { s; } while (--t)
 
-    if ((unsigned long)dst < (unsigned long)src) {
+    if (dst < src) {
         t = (zr_ptr)src; /* only need low bits */
         if ((t | (zr_ptr)dst) & wmask) {
             if ((t ^ (zr_ptr)dst) & wmask || length < wsize)


### PR DESCRIPTION
I'm on windows10 64bit msys64.
```
gcc (Rev4, Built by MSYS2 project) 5.2.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
clang version 3.7.0 (tags/RELEASE_370/final)
Target: x86_64-w64-windows-gnu
Thread model: posix
```
