### PR TITLE
Show and hide onscreen keyboard

### DIFF
--- a/demo/apple/ZahnradBackend.h
+++ b/demo/apple/ZahnradBackend.h
@@ -21,6 +21,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "zahnrad.h"
+
 #define SIMULATE_TOUCH 0
 
 #if (TARGET_OS_IPHONE && (!TARGET_OS_TV)) || SIMULATE_TOUCH
@@ -57,12 +59,6 @@
 @end
 
 
-struct zr_context;
-struct zr_buffer;
-struct zr_allocator;
-struct zr_user_font;
-
-
 @interface ZahnradBackend (Adapter)
 
 
@@ -74,4 +70,12 @@ struct zr_user_font;
 
 
 @end
+
+
+void zr_backend_show_keyboard(zr_hash hash, struct zr_rect bounds, struct zr_buffer* text);
+void zr_backend_hide_keyboard(void);
+
+int zr_touch_edit_string(struct zr_context *ctx, zr_flags flags, char *text, zr_size *len, zr_size max, zr_filter filter, zr_hash unique_id);
+
+
 

--- a/demo/apple/ZahnradBackend.m
+++ b/demo/apple/ZahnradBackend.m
@@ -726,15 +726,17 @@ void zr_backend_hide_keyboard(void)
 
 int zr_touch_edit_string(struct zr_context *ctx, zr_flags flags, char *text, zr_size *len, zr_size max, zr_filter filter, zr_hash unique_id)
 {
-    zr_flags state = zr_edit_string(ctx, flags, text, len, max, filter);
+    zr_flags state;
+    struct zr_rect bounds;
+    
+    zr_layout_peek(&bounds, ctx);
+    state = zr_edit_string(ctx, flags, text, len, max, filter);
     if (state & ZR_EDIT_ACTIVATED)
     {
-        struct zr_rect bounds;
         struct zr_buffer buffer;
         zr_buffer_init_fixed(&buffer, text, max);
         buffer.allocated = *len;
         
-        zr_layout_peek(&bounds, ctx);
         zr_backend_show_keyboard((zr_hash)unique_id, bounds, &buffer);
     }
     else if (state & ZR_EDIT_DEACTIVATED)

--- a/demo/apple/ZahnradBackend.m
+++ b/demo/apple/ZahnradBackend.m
@@ -19,6 +19,8 @@
  3.  This notice may not be removed or altered from any source distribution.
  */
 
+#import "ZahnradBackend.h"
+
 
 #define MAX_VERTEX_MEMORY   (512 * 1024)
 #define MAX_ELEMENT_MEMORY  (128 * 1024)
@@ -28,23 +30,17 @@
 // #else does provide a generic version to start
 // your own project.
 
+
 #if 1
 
+#if TARGET_OS_IPHONE
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <math.h>
+#define zr_edit_string(_ct, _fl, _bu, _le, _ma, _fi) zr_touch_edit_string(_ct, _fl, _bu, _le, _ma, _fi, (zr_hash)__COUNTER__)
 
-#include "zahnrad.h"
+#endif
+
+
 #include "../demo.c"
-
-#undef MAX
-#undef MIN
-
-#import "ZahnradBackend.h"
 
 
 @implementation ZahnradBackend (Adapter)
@@ -79,7 +75,6 @@ static struct demo gui;
 
 
 #import "ZahnradBackend.h"
-#import "zahnrad.h"
 
 
 @implementation ZahnradBackend (Adapter)
@@ -700,6 +695,9 @@ static void mem_free(zr_handle unused, void* ptr)
 @end
 
 
+#undef zr_edit_string
+
+
 #if TARGET_OS_IPHONE
 
 
@@ -726,16 +724,44 @@ void zr_backend_hide_keyboard(void)
 }
 
 
+int zr_touch_edit_string(struct zr_context *ctx, zr_flags flags, char *text, zr_size *len, zr_size max, zr_filter filter, zr_hash unique_id)
+{
+    zr_flags state = zr_edit_string(ctx, flags, text, len, max, filter);
+    if (state & ZR_EDIT_ACTIVATED)
+    {
+        struct zr_rect bounds;
+        struct zr_buffer buffer;
+        zr_buffer_init_fixed(&buffer, text, max);
+        buffer.allocated = *len;
+        
+        zr_layout_peek(&bounds, ctx);
+        zr_backend_show_keyboard((zr_hash)unique_id, bounds, &buffer);
+    }
+    else if (state & ZR_EDIT_DEACTIVATED)
+    {
+        zr_backend_hide_keyboard();
+    }
+    
+    return state;
+}
+
+
 #else
 
 
-void zr_backend_show_keyboard(zr_hash zrHash, struct zr_rect zrBounds)
+void zr_backend_show_keyboard(zr_hash zrHash, struct zr_rect zrBounds, struct zr_buffer* zrText)
 {
 }
 
 
 void zr_backend_hide_keyboard(void)
 {
+}
+
+
+int zr_touch_edit_string(struct zr_context *ctx, zr_flags flags, char *text, zr_size *len, zr_size max, zr_filter filter, zr_hash unique_id)
+{
+    return  zr_edit_string(ctx, flags, text, len, max, filter);
 }
 
 

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -1,8 +1,14 @@
 #include "limits.h"
 
-#define MIN(a,b)    ((a) < (b) ? (a) : (b))
-#define MAX(a,b)    ((a) < (b) ? (b) : (a))
+#ifndef MIN
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a,b) ((a) < (b) ? (b) : (a))
+#endif
+#ifndef CLAMP
 #define CLAMP(i,v,x) (MAX(MIN(v,x), i))
+#endif
 #define LEN(a)      (sizeof(a)/sizeof(a)[0])
 #define UNUSED(a)   ((void)(a))
 


### PR DESCRIPTION
This contains an example how to automatically show and hide a onscreen keyboard. The logic is implemented in zr_touch_edit_string (ZahnradBackend.m)